### PR TITLE
Dockerfile für Vapor 4.x

### DIFF
--- a/swift/Dockerfile
+++ b/swift/Dockerfile
@@ -1,11 +1,12 @@
-FROM ubuntu:18.04
-SHELL ["/bin/bash", "-c"]
-RUN apt-get update && \
-  apt-get install -y curl && \
-  eval "$(curl -sL https://apt.vapor.sh | \
-          sed 's,python-software-properties,,')" && \
-  apt-get install -y vapor && \
-  rm -rf /var/lib/apt/lists/*
+FROM swift:5.2
+
+WORKDIR /tmp
+RUN git clone https://github.com/vapor/toolbox.git && \
+    cd toolbox && \
+    make install
+
+RUN rm -rf /tmp/*
 WORKDIR /swiftcode
+
 RUN git config --global user.email "you@example.com" \
  && git config --global user.name  "Your Name"


### PR DESCRIPTION
## 🧨  Problem

Mit Vapor 4.x wurde die Installationsanleitung angepasst. Vapor kann nun nicht mehr über das Shell-Skript `https://apt.vapor.sh` installiert werden. Die Seite existiert nicht mehr.

## 📝 Lösung

Gemäß der offiziellen [Anleitung](https://docs.vapor.codes/4.0/install/linux/#install-toolbox) muss Vapor nun über die Vapor-Toolbox mit `make install` installiert werden. Dafür kann dann auch direkt das offizielle Swift-Image verwendet werden.

